### PR TITLE
fix focus in book-input-decorator.js

### DIFF
--- a/src/components/book-input-decorator.js
+++ b/src/components/book-input-decorator.js
@@ -80,6 +80,7 @@ class BookInputDecorator extends LitElement {
       <slot name="button"></slot>
     `;
   }
+  
   static get properties() {
     return {
       _focused: Boolean

--- a/src/components/book-input-decorator.js
+++ b/src/components/book-input-decorator.js
@@ -80,6 +80,11 @@ class BookInputDecorator extends LitElement {
       <slot name="button"></slot>
     `;
   }
+  static get properties() {
+    return {
+      _focused: Boolean
+    }
+  }
 
   async _firstRendered() {
     // Do all setup work after the first render.


### PR DESCRIPTION
Seems that the _focused property had to be explicitly declared to work properly.